### PR TITLE
added logic to handle case of 0 instances

### DIFF
--- a/asg.cfn.yml.tpl
+++ b/asg.cfn.yml.tpl
@@ -14,7 +14,7 @@ Resources:
       AutoScalingCreationPolicy:
         MinSuccessfulInstancesPercent: 80
       ResourceSignal:
-        Count: 1
+        Count: %{ if desiredCapacity > 0 }1%{ else }0%{ endif }
         Timeout: PT30M    # Set long creation timeout so you can ssh in to troubleshoot if needed
     UpdatePolicy:
     # Ignore differences in group size properties caused by scheduled actions
@@ -31,5 +31,5 @@ Resources:
           - AZRebalance
           - AlarmNotification
           - ScheduledActions
-        WaitOnResourceSignals: true
+        WaitOnResourceSignals: %{ if desiredCapacity > 0 }true%{ else }false%{ endif }
     DeletionPolicy: Delete


### PR DESCRIPTION
When there were 0 instances (for a fargate cluster) the terraform would run indefinitely because there were no nodes to respond to the healthcheck 