### PR TITLE
plz, make the error messages stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@
 | max\_instances | Max instances in ASG | `number` | `4` | no |
 | min\_instances | Min instances in ASG | `number` | `2` | no |
 | name | common name for resources in this module | `string` | `"ecs_cluster"` | no |
-| ssh\_key\_pair\_name | Name of pre-existing key-pair for use with the EC2 launch config. One of `ssh_pubkey` or `ssh_key_pair_name` is required | `string` | `""` | no |
-| ssh\_pubkey | Public key for default ssh key. One of `ssh_pubkey` or `ssh_key_pair_name` is required | `string` | `""` | no |
+| ssh\_key\_pair\_name | Name of pre-existing key-pair for use with the EC2 launch config. | `string` | `""` | no |
 | tags | common tags for all resources | `map(string)` | `{}` | no |
 | userdata\_script | Bash commands to be passed to the instance as userdata. Do NOT include a shebang. | `string` | `"echo 'No additional userdata was passed'"` | no |
 | volume\_size | Size of root volume of ECS instances | `number` | `100` | no |

--- a/launch_config.tf
+++ b/launch_config.tf
@@ -6,9 +6,6 @@
 locals {
   get_latest_ami = var.ami_id == ""
   ami_id         = coalesce(var.ami_id, data.aws_ami.this[0].image_id)
-
-  create_key_pair = var.ssh_key_pair_name == ""
-  key_pair_name   = coalesce(var.ssh_key_pair_name, aws_key_pair.this[0].key_name)
 }
 
 data "aws_ami" "this" {
@@ -29,22 +26,11 @@ data "aws_ami" "this" {
   }
 }
 
-resource "aws_key_pair" "this" {
-  count = local.create_key_pair ? 1 : 0
-
-  key_name_prefix = "${var.name}-ssh-key-"
-  public_key      = var.ssh_pubkey
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_launch_configuration" "this" {
   name_prefix                 = "${var.name}-lc-"
   associate_public_ip_address = var.assign_ec2_public_ip #tfsec:ignore:AWS012
   ebs_optimized               = true
-  key_name                    = local.key_pair_name
+  key_name                    = var.ssh_key_pair_name
   iam_instance_profile        = aws_iam_instance_profile.ecs_instance_profile.id
   image_id                    = local.ami_id
   instance_type               = var.instance_type

--- a/variables.tf
+++ b/variables.tf
@@ -73,15 +73,9 @@ variable "name" {
   type        = string
 }
 
-variable "ssh_pubkey" {
-  default     = ""
-  description = "Public key for default ssh key. One of `ssh_pubkey` or `ssh_key_pair_name` is required"
-  type        = string
-}
-
 variable "ssh_key_pair_name" {
   default     = ""
-  description = "Name of pre-existing key-pair for use with the EC2 launch config. One of `ssh_pubkey` or `ssh_key_pair_name` is required"
+  description = "Name of pre-existing key-pair for use with the EC2 launch config."
   type        = string
 }
 


### PR DESCRIPTION
```
Error: Invalid count argument

  on .terraform/modules/ecs_cluster/terraform-aws-ecs-cluster-2.0.0/launch_config.tf line 33, in resource "aws_key_pair" "this":
  33:   count = local.create_key_pair ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

So I `-target`, and 

```
Error: Invalid index

  on .terraform/modules/ecs_cluster/terraform-aws-ecs-cluster-2.0.0/launch_config.tf line 11, in locals:
  11:   key_pair_name   = coalesce(var.ssh_key_pair_name, aws_key_pair.this[0].key_name)
    |----------------
    | aws_key_pair.this is empty tuple

The given key does not identify an element in this collection value.
```